### PR TITLE
Update to resolve puppet resource package call

### DIFF
--- a/lib/puppet/provider/package/te_agent_bin.rb
+++ b/lib/puppet/provider/package/te_agent_bin.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/package'
 
-Puppet::Type.type(:package).provide(:te_agent_bin, :parent => Puppet::Provider::Package) do
+Puppet::Type.type(:package).provide(:dpkg, :parent => Puppet::Provider::Package) do
   desc "Support for managing the TE Agent package on non-Windows systems.
 
   This provider requires a `source` attribute when installing the package,


### PR DESCRIPTION
te_agent_bin is not a valid base provider and breaks the puppet resource package command for servers that have the te_agent module installed.  Please see puppet docs for further information: https://docs.puppet.com/puppet/5.1/provider_development.html#base-provider